### PR TITLE
🔍 fix: Serper link typo in Docs

### DIFF
--- a/pages/docs/configuration/librechat_yaml/object_structure/web_search.mdx
+++ b/pages/docs/configuration/librechat_yaml/object_structure/web_search.mdx
@@ -53,7 +53,7 @@ webSearch:
   ]}
 />
 
-**Note:** Get your API key from [Serper.dev](https://serper.dev/api-key)
+**Note:** Get your API key from [Serper.dev](https://serper.dev/api-keys)
 
 
 ### searxngInstanceUrl


### PR DESCRIPTION
Current link was a 404